### PR TITLE
Compatibility with Rails5

### DIFF
--- a/lib/cic_payment.rb
+++ b/lib/cic_payment.rb
@@ -54,14 +54,14 @@ class CicPayment < PaymentSettings
     if verify_hmac(params)
       case params['code-retour']
       when "Annulation"
-        params.update(:success => false)
+        params.merge(:success => false)
       when "payetest", "paiement"
-        params.update(:success => true)
+        params.merge(:success => true)
       else
-        params.update(:success => false)
+        params.merge(:success => false)
       end
     else
-      params.update(:success => false)
+      params.merge(:success => false)
     end
   end
   


### PR DESCRIPTION
Hi there :)

Since `ActionController::Parameters` no longer inherits from `HashWithIndifferentAccess` in Rails5, we cannot longer use the `update` method to merge **success** param to params in `CicPayment#response` method.

I replaced it with `ActionController::Parameters#merge` method.